### PR TITLE
feat: add self-disable step to template setup workflow

### DIFF
--- a/.cursor/rules/template_setup.mdc
+++ b/.cursor/rules/template_setup.mdc
@@ -1,6 +1,6 @@
 ---
 description: Detailed steps for template setup workflow when initializing a project
-alwaysApply: false
+alwaysApply: true
 ---
 
 # Template Setup Workflow
@@ -30,3 +30,8 @@ When a user prompts "initialize this project as <my project name>", I will **ONL
 
 ## After Template Initialization
 Template initialization is complete after customizing the project files. TaskMaster, PRD creation, and git setup are separate workflows that require explicit user requests.
+
+### Final Step: Remove from Context Window
+After completing template initialization, update this rule file to stop consuming context space:
+- **Change `alwaysApply: true` to `alwaysApply: false`** in the frontmatter of `.cursor/rules/template_setup.mdc`
+- This prevents the detailed template setup instructions from taking up context window space after the one-time setup is complete


### PR DESCRIPTION
This PR adds a clever self-modifying feature to the template setup workflow that optimizes context window usage.

## Problem
The template setup workflow needed to be visible during initialization () so agents could see the detailed instructions, but this caused the detailed instructions to consume context window space even after the one-time setup was complete.

## Solution
Added a final step to the template setup workflow that instructs the agent to change  to  after template initialization is complete.

## How it Works
1. **During template initialization**: The rule is visible () so agents can see detailed instructions
2. **After template setup is complete**: The agent changes the frontmatter to  
3. **Future sessions**: The detailed template setup instructions don't consume context window space
4. **If needed later**: Instructions can still be accessed via the reference in workflow.mdc

## Benefits
- ✅ **Detailed instructions available** during one-time setup
- ✅ **Context window space preserved** after setup is complete  
- ✅ **Self-managing rule** that optimizes itself automatically
- ✅ **No loss of functionality** - instructions remain accessible when needed

## Changes Made
- Added "Final Step: Remove from Context Window" section to template_setup.mdc
- Provides clear instructions for the agent to modify the rule's frontmatter
- Explains the purpose and benefits of this optimization

This creates an elegant solution for managing context usage while maintaining accessibility to detailed instructions.